### PR TITLE
bake

### DIFF
--- a/79_bake/Dockerfile.ffmpeg
+++ b/79_bake/Dockerfile.ffmpeg
@@ -2,8 +2,8 @@
 ARG baseimage="scratch"
 FROM nixos/nix:latest AS BUILDER
 
-ARG NIX_FILE=./jq.nix 
-ARG PROGRAM_FILE=jq 
+ARG NIX_FILE=./ffmpeg-full.nix 
+ARG PROGRAM_FILE=ffmpeg 
 
 WORKDIR /scratch
 COPY $NIX_FILE .
@@ -32,5 +32,5 @@ FROM $baseimage AS PRODUCTION
 COPY --from=BUILDER /output/bin/$PROGRAM_FILE /usr/bin/$PROGRAM_FILE
 COPY --from=BUILDER /output/libs /
 
-ENTRYPOINT [ "/usr/bin/jq" ]
-CMD ["/usr/bin/jq", "--version"]
+ENTRYPOINT [ "/usr/bin/ffmpeg" ]
+CMD ["/usr/bin/ffmpeg", "--version"]

--- a/79_bake/Dockerfile.jq
+++ b/79_bake/Dockerfile.jq
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1.4
+FROM nixos/nix:latest AS BUILDER
+
+WORKDIR /scratch
+COPY jq.nix .
+RUN nix-build ./jq.nix
+
+RUN find /nix/store -name "ldd" 
+
+# NOTE: Escape the \$ otherwise they are rendered at buildtime
+COPY <<EOF /scratch/exportldd.sh
+#!/usr/bin/env bash
+/nix/store/h0cnbmfcn93xm5dg2x27ixhag1cwndga-glibc-2.34-210-bin/bin/ldd "./result/bin/jq" >  /scratch/libs.txt
+cat /scratch/libs.txt | /nix/store/w3p77mkdy3pigg12iyha8y9dqakhjsxn-gawk-5.1.1/bin/awk 'NF == 4 { {print \$3} }' > /scratch/libs_extracted.txt    
+cat /scratch/libs_extracted.txt | /nix/store/w3p77mkdy3pigg12iyha8y9dqakhjsxn-gawk-5.1.1/bin/awk -F/ -vOFS=/ '{ print \$1,\$2,\$3,\$4; }' | sort -u > /scratch/libs_paths.txt
+tar -cvf /scratch/libraries.tar -T /scratch/libs_paths.txt
+mkdir /output
+tar xf /scratch/libraries.tar --directory=/output
+EOF
+RUN chmod +x /scratch/exportldd.sh
+RUN /scratch/exportldd.sh
+CMD ["./result/bin/jq", "--version"]
+
+FROM gcr.io/distroless/nodejs:16-debug AS PRODUCTION
+
+COPY --from=BUILDER /scratch/result/bin/jq /usr/bin/jq
+COPY --from=BUILDER /output /
+
+ENTRYPOINT [ "/usr/bin/jq" ]
+CMD ["/usr/bin/jq", "--version"]

--- a/79_bake/Dockerfile.sox
+++ b/79_bake/Dockerfile.sox
@@ -2,8 +2,8 @@
 ARG baseimage="scratch"
 FROM nixos/nix:latest AS BUILDER
 
-ARG NIX_FILE=./jq.nix 
-ARG PROGRAM_FILE=jq 
+ARG NIX_FILE=./sox.nix 
+ARG PROGRAM_FILE=sox 
 
 WORKDIR /scratch
 COPY $NIX_FILE .
@@ -26,11 +26,9 @@ RUN chmod +x /scratch/exportldd.sh && /scratch/exportldd.sh
 CMD ["./output/bin/$PROGRAM_FILE", "--version"]
 
 FROM $baseimage AS PRODUCTION
-#FROM scratch AS PRODUCTION
-#FROM gcr.io/distroless/nodejs:16 AS PRODUCTION
 
 COPY --from=BUILDER /output/bin/$PROGRAM_FILE /usr/bin/$PROGRAM_FILE
 COPY --from=BUILDER /output/libs /
 
-ENTRYPOINT [ "/usr/bin/jq" ]
-CMD ["/usr/bin/jq", "--version"]
+ENTRYPOINT [ "/usr/bin/sox" ]
+CMD ["/usr/bin/sox", "--version"]

--- a/79_bake/README.md
+++ b/79_bake/README.md
@@ -1,10 +1,40 @@
 # README
 
+Demonstrate how to use `bake`  
+
+TODO:
+
+* Build multiple nix images and merge them into one.  
+* Build with multiple contexts.  
+
+## jq build
+
+```sh
+# build the packages 
+docker build --no-cache --progress=plain -f Dockerfile.jq --target BUILDER -t nix-jq .  
+docker build --no-cache --progress=plain -f Dockerfile.jq --target PRODUCTION -t nix-jq .    
+
+# run to prove jq works
+docker run --rm -it nix-jq
+
+docker run --rm -it --entrypoint /busybox/sh nix-jq 
+
+dive nix-jq
+
+```
+
+```sh
+docker buildx bake --print
+```
 
 ## Resource
+
 https://docs.docker.com/engine/reference/commandline/buildx_bake/
 
 https://github.com/docker/buildx
 
 Docker Bake example
 https://blog.kubesimplify.com/bake-your-container-images-with-bake
+
+https://github.com/developer-guy/hello-world-buildx
+

--- a/79_bake/README.md
+++ b/79_bake/README.md
@@ -1,43 +1,28 @@
 # README
 
-Demonstrate how to use `bake`  
+Demonstrate how to use `bake` to build multiple images.  
 
-TODO:
+REF: Nix 09_distroless [here](https://github.com/chrisguest75/nix-examples/blob/master/09_distroless/README.md)  
 
-* Build multiple nix images and merge them into one.  
-* Build with multiple contexts.  
+## Bake
 
-## jq build
+```bash
+# use bake to build all the images
+docker buildx bake --metadata-file ./bake-metadata.json  
+docker buildx bake --metadata-file ./bake-metadata.json --no-cache 
 
-```sh
-# build the packages 
-docker build --no-cache --progress=plain -f Dockerfile.jq --target BUILDER -t nix-jq .  
-docker build --no-cache --progress=plain -f Dockerfile.jq --target PRODUCTION -t nix-jq .    
-
-# run to prove jq works
-docker run --rm -it nix-jq
-
-docker run --rm -it --entrypoint /busybox/sh nix-jq 
-
-dive nix-jq
-
+while IFS=, read -r imagesha
+do
+    echo "IMAGE:$imagesha"
+    docker run --rm -t "$imagesha" --version
+done < <(jq -r '. | keys[] as $key | .[$key]."containerimage.digest"' ./bake-metadata.json)
 ```
 
-```sh
-docker buildx bake --print
-```
+## Resources
 
-## Resource
-
-https://docs.docker.com/engine/reference/commandline/buildx_bake/
-
-https://github.com/docker/buildx
-
-Docker Bake example
-https://blog.kubesimplify.com/bake-your-container-images-with-bake
-
-https://github.com/developer-guy/hello-world-buildx
-
-https://docs.docker.com/build/customize/bake/hcl-funcs/
-
-https://docs.docker.com/build/customize/bake/
+* docker buildx bake [here](https://docs.docker.com/engine/reference/commandline/buildx_bake/)
+* User defined HCL functions [here](https://docs.docker.com/build/customize/bake/hcl-funcs/)
+* High-level build options with Bake [here](https://docs.docker.com/build/customize/bake/)
+* buildx repo [here](https://github.com/docker/buildx)
+* Bake your Container Images with Bake [here](https://blog.kubesimplify.com/bake-your-container-images-with-bake)
+* developer-guy/hello-world-buildx repo [here](https://github.com/developer-guy/hello-world-buildx)

--- a/79_bake/README.md
+++ b/79_bake/README.md
@@ -1,0 +1,10 @@
+# README
+
+
+## Resource
+https://docs.docker.com/engine/reference/commandline/buildx_bake/
+
+https://github.com/docker/buildx
+
+Docker Bake example
+https://blog.kubesimplify.com/bake-your-container-images-with-bake

--- a/79_bake/README.md
+++ b/79_bake/README.md
@@ -38,3 +38,6 @@ https://blog.kubesimplify.com/bake-your-container-images-with-bake
 
 https://github.com/developer-guy/hello-world-buildx
 
+https://docs.docker.com/build/customize/bake/hcl-funcs/
+
+https://docs.docker.com/build/customize/bake/

--- a/79_bake/docker-bake.hcl
+++ b/79_bake/docker-bake.hcl
@@ -1,0 +1,36 @@
+variable "TAG" {
+  default = "latest"
+}
+
+target "_common" {
+  args = {
+    BUILDKIT_CONTEXT_KEEP_GIT_DIR = 1
+  }
+}
+
+// docker-bake.hcl
+target "docker-metadata-action" {
+  tags = ["nix-jq:${TAG}"]
+}
+
+group "default" {
+  targets = ["image"]
+}
+
+target "image" {
+ inherits = ["_common", "docker-metadata-action"]
+ context = "."
+ dockerfile = "Dockerfile.jq"
+ #cache-from = ["type=registry,ref=${GITHUB_REPOSITORY_OWNER}/hello-world-buildx:latest"]
+ #cache-to = ["type=inline"]
+ labels = {
+   "org.opencontainers.image.title"= "nix-jq:${TAG}"
+ }
+ #output = ["type=registry"]
+}
+
+target "image-all" {
+ inherits = ["image"]
+ platforms = ["linux/amd64"]
+ output = ["type=registry"]
+}

--- a/79_bake/docker-bake.hcl
+++ b/79_bake/docker-bake.hcl
@@ -1,36 +1,105 @@
+
 variable "TAG" {
   default = "latest"
 }
-
-target "_common" {
-  args = {
-    BUILDKIT_CONTEXT_KEEP_GIT_DIR = 1
-  }
+variable "DISTROLESS" {
+  default = "gcr.io/distroless/nodejs:16"
+}
+variable "SCRATCH" {
+  default = "scratch"
 }
 
-// docker-bake.hcl
-target "docker-metadata-action" {
-  tags = ["nix-jq:${TAG}"]
+#***********************************************
+# JQ images
+#***********************************************
+
+target "jq-image" {
+  args = {"NIX_FILE":"jq.nix", "PROGRAM_FILE":"jq"}
+  context = "."
+  dockerfile = "Dockerfile.jq"
+}
+
+target "jq-image-distroless" {
+  inherits = ["jq-image"]
+  args = {"baseimage":"${DISTROLESS}"}
+  labels = {
+    "org.opencontainers.image.title"= "nix-jq-distroless:${TAG}"
+  }
+  tags = ["nix-jq-distroless:${TAG}"]
+}
+
+target "jq-image-scratch" {
+  inherits = ["jq-image"]
+  args = {"baseimage":"${SCRATCH}"}
+  labels = {
+    "org.opencontainers.image.title"= "nix-jq-scratch:${TAG}"
+  }
+  tags = ["nix-jq-scratch:${TAG}"]
+}
+
+#***********************************************
+# SOX images
+#***********************************************
+
+target "sox-image" {
+  args = {"NIX_FILE":"sox.nix", "PROGRAM_FILE":"sox"}
+  context = "."
+  dockerfile = "Dockerfile.sox"
+}
+
+target "sox-image-distroless" {
+  inherits = ["sox-image"]
+  args = {"baseimage":"${DISTROLESS}"}
+  labels = {
+    "org.opencontainers.image.title"= "nix-sox-distroless:${TAG}"
+  }
+  tags = ["nix-sox-distroless:${TAG}"]
+}
+
+target "sox-image-scratch" {
+  inherits = ["sox-image"]
+  args = {"baseimage":"${SCRATCH}"}
+  labels = {
+    "org.opencontainers.image.title"= "nix-sox-scratch:${TAG}"
+  }
+  tags = ["nix-sox-scratch:${TAG}"]
+}
+
+#***********************************************
+# ffmpeg images
+#***********************************************
+
+target "ffmpeg-image" {
+  args = {"NIX_FILE":"ffmpeg-full.nix", "PROGRAM_FILE":"ffmpeg"}
+  context = "."
+  dockerfile = "Dockerfile.ffmpeg"
+}
+
+target "ffmpeg-image-distroless" {
+  inherits = ["ffmpeg-image"]
+  args = {"baseimage":"${DISTROLESS}"}
+  labels = {
+    "org.opencontainers.image.title"= "nix-ffmpeg-distroless:${TAG}"
+  }
+  tags = ["nix-ffmpeg-distroless:${TAG}"]
+}
+
+target "ffmpeg-image-scratch" {
+  inherits = ["ffmpeg-image"]
+  args = {"baseimage":"${SCRATCH}"}
+  labels = {
+    "org.opencontainers.image.title"= "nix-ffmpeg-scratch:${TAG}"
+  }
+  tags = ["nix-ffmpeg-scratch:${TAG}"]
 }
 
 group "default" {
-  targets = ["image"]
-}
-
-target "image" {
- inherits = ["_common", "docker-metadata-action"]
- context = "."
- dockerfile = "Dockerfile.jq"
- #cache-from = ["type=registry,ref=${GITHUB_REPOSITORY_OWNER}/hello-world-buildx:latest"]
- #cache-to = ["type=inline"]
- labels = {
-   "org.opencontainers.image.title"= "nix-jq:${TAG}"
- }
- #output = ["type=registry"]
-}
-
-target "image-all" {
- inherits = ["image"]
- platforms = ["linux/amd64"]
- output = ["type=registry"]
+  targets = [
+    "jq-image-distroless", 
+    "jq-image-scratch",
+    "sox-image-distroless", 
+    "sox-image-scratch",
+    "ffmpeg-image-distroless", 
+    "ffmpeg-image-scratch"
+    ]
 }

--- a/79_bake/ffmpeg-full.nix
+++ b/79_bake/ffmpeg-full.nix
@@ -1,0 +1,10 @@
+with import <nixpkgs> {};
+
+buildEnv {
+  name = "buildjq";
+  paths = [ 
+    ffmpeg-full 
+    gawk 
+  ];
+}
+

--- a/79_bake/jq.nix
+++ b/79_bake/jq.nix
@@ -1,0 +1,9 @@
+with import <nixpkgs> {};
+
+buildEnv {
+  name = "buildjq";
+  paths = [ 
+    jq 
+    gawk 
+  ];
+}

--- a/79_bake/sox.nix
+++ b/79_bake/sox.nix
@@ -1,0 +1,9 @@
+with import <nixpkgs> {};
+
+buildEnv {
+  name = "buildsox";
+  paths = [ 
+    sox 
+    gawk 
+  ];
+}


### PR DESCRIPTION
- Add a skopeo example. (#53)
- Add environment variables to containers running in compose
- Scaling compose services example.
- Start building and rebuilding images manually (#56)
- Start an example for buildah (#57)
- Add troubleshooting examples
- Try an onbuild example (#58)
- onbuild added to readme.
- Update todo on readme.
- skaffold (#59)
- Update the apt-locking example
- Tidy up a lot of the readmes and try a few new documentation ideas out.
- Create a resty nginx server and test some healthchecks
- ERROR_RATE  is now configurable
- Finish up the healthcheck with openresty example
- Update readme
- Tidy up bits and pieces
- Add a multiple docker context example
- Improve semgrep instructions and switch nonroot and root.
- Add examples for sharing a port with nginx.
- Update a couple of READMEs
- Add a local docker skaffold example sharing in AWS profile and environment varaibles.
- Improve the skaffold aws example to split the profile copy into a seperate target.
- Tidy up skaffold docs
- Tidy up main readme.
- Prepare for a bake example
