### PR TITLE
cachemount

### DIFF
--- a/16_cache_fails/README.md
+++ b/16_cache_fails/README.md
@@ -1,7 +1,7 @@
 # CACHE FAILS
 
 Demonstrate layer caching behaviour with non-deterministic commands.
-We pull the time from a time service to demonstrate the non-determinism. This would be akin to any command requiring an updated file. 
+We pull the time from a time service to demonstrate the non-determinism. This would be akin to any command requiring an updated file.  
 
 ## Script to follow
 
@@ -57,7 +57,7 @@ Step 3/7 : RUN echo "Hello"
 ...
 ```
 
-Therefore, the image is not rebuilt and we have an old file.
+Therefore, the image is not rebuilt and we have an old file.  
 
 ```sh
 docker run -it --rm 16_cache_fails

--- a/86_cache_mounts/.gitignore
+++ b/86_cache_mounts/.gitignore
@@ -1,0 +1,1 @@
+modifyme.txt

--- a/86_cache_mounts/Dockerfile.buildcache
+++ b/86_cache_mounts/Dockerfile.buildcache
@@ -1,0 +1,69 @@
+# syntax=docker/dockerfile:1.4
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# NOTE: Escape the \$ otherwise they are rendered at buildtime
+COPY --chmod=755 <<EOF /bin/folders.sh
+#!/usr/bin/env bash
+echo "> *************** /var/lib/apt"
+ls -lR /var/lib/apt
+
+echo "> *************** /var/cache/apt"
+ls -lR /var/cache/apt
+
+echo "> *************** /etc/apt/apt.conf.d"
+ls -lR /etc/apt/apt.conf.d
+
+apt-config dump | grep -i cache
+
+echo "> *************** /etc/apt/apt.conf.d/docker-autoremove-suggests"
+cat /etc/apt/apt.conf.d/docker-autoremove-suggests
+
+echo "> *************** /etc/apt/apt.conf.d/docker-disable-periodic-update"
+cat /etc/apt/apt.conf.d/docker-disable-periodic-update
+
+echo "> *************** /etc/apt/apt.conf.d/docker-gzip-indexes"
+cat /etc/apt/apt.conf.d/docker-gzip-indexes
+
+echo "> *************** /etc/apt/apt.conf.d/docker-no-languages"
+cat /etc/apt/apt.conf.d/docker-no-languages
+
+echo "> *************** /etc/apt/apt.conf.d/keep-cache"
+cat /etc/apt/apt.conf.d/keep-cache
+EOF
+
+#ARG CURL_VERSION=7.47.0-1ubuntu2.14
+ARG CURL_VERSION=7.81.0-1ubuntu1.6
+
+RUN /bin/folders.sh && \
+    rm -f /etc/apt/apt.conf.d/docker-clean; \
+    echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' \
+    > /etc/apt/apt.conf.d/keep-cache
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    set -x; \
+    /bin/folders.sh \
+    && apt update && apt-cache madison curl \
+    && apt install -fy -qq --no-install-recommends jq ca-certificates curl=${CURL_VERSION} \
+    && /bin/folders.sh 
+
+#    && apt-get clean \
+#    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-cache madison bash curl
+RUN apt list --installed bash curl -a
+
+# NOTE: Escape the \$ otherwise they are rendered at buildtime
+COPY --chmod=755 <<EOF /bin/check.sh
+#!/usr/bin/env bash
+curl --version
+jq --version
+
+/bin/folders.sh
+EOF
+
+
+# NOTE: This is not required as there is an undocumented flag --chmod
+ENTRYPOINT ["/bin/check.sh"]
+CMD [""]

--- a/86_cache_mounts/Dockerfile.buildcache
+++ b/86_cache_mounts/Dockerfile.buildcache
@@ -3,6 +3,10 @@ FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# this triggers a full rebuild allowing us to look at the cache
+WORKDIR /scratch
+COPY modifyme.txt modifyme.txt
+
 # NOTE: Escape the \$ otherwise they are rendered at buildtime
 COPY --chmod=755 <<EOF /bin/folders.sh
 #!/usr/bin/env bash
@@ -34,12 +38,13 @@ cat /etc/apt/apt.conf.d/keep-cache
 EOF
 
 #ARG CURL_VERSION=7.47.0-1ubuntu2.14
-ARG CURL_VERSION=7.81.0-1ubuntu1.6
+ARG CURL_VERSION=7.81.0-1ubuntu1.14
 
 RUN /bin/folders.sh && \
     rm -f /etc/apt/apt.conf.d/docker-clean; \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' \
     > /etc/apt/apt.conf.d/keep-cache
+
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     set -x; \

--- a/86_cache_mounts/Dockerfile.customcache
+++ b/86_cache_mounts/Dockerfile.customcache
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1.4
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+WORKDIR /scratch
+COPY modifyme.txt modifyme.txt
+
+# NOTE: Escape the \$ otherwise they are rendered at buildtime
+COPY --chmod=755 <<EOF /bin/folders.sh
+#!/usr/bin/env bash
+echo "> *************** /mycache"
+ls -lR /mycache
+
+EOF
+
+COPY --chmod=755 <<EOF /bin/addcache.sh
+#!/usr/bin/env bash
+BUILDTIME=\$(date "+%Y%m%d-%H%M%S")
+echo "File was built \$BUILDTIME" 
+echo "File was built \$BUILDTIME" > /mycache/\$BUILDTIME
+
+EOF
+
+RUN --mount=type=cache,target=/mycache,sharing=locked \
+    /bin/folders.sh 
+
+RUN --mount=type=cache,target=/mycache,sharing=locked \
+    /bin/addcache.sh 
+
+RUN --mount=type=cache,target=/mycache,sharing=locked \
+    /bin/folders.sh 
+
+# NOTE: This is not required as there is an undocumented flag --chmod
+ENTRYPOINT ["/bin/folders.sh"]
+CMD [""]

--- a/86_cache_mounts/Dockerfile.showcache
+++ b/86_cache_mounts/Dockerfile.showcache
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.4
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# NOTE: Escape the \$ otherwise they are rendered at buildtime
+COPY --chmod=755 <<EOF /bin/folders.sh
+#!/usr/bin/env bash
+echo "> *************** /var/lib/apt"
+ls -lR /var/lib/apt
+
+echo "> *************** /var/cache/apt"
+ls -lR /var/cache/apt
+EOF
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    /bin/folders.sh 
+
+# NOTE: This is not required as there is an undocumented flag --chmod
+ENTRYPOINT ["/bin/folders.sh"]
+CMD [""]

--- a/86_cache_mounts/Dockerfile.showcache
+++ b/86_cache_mounts/Dockerfile.showcache
@@ -3,6 +3,10 @@ FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+# this triggers a full rebuild allowing us to look at the cache
+WORKDIR /scratch
+COPY modifyme.txt modifyme.txt
+
 # NOTE: Escape the \$ otherwise they are rendered at buildtime
 COPY --chmod=755 <<EOF /bin/folders.sh
 #!/usr/bin/env bash
@@ -16,6 +20,10 @@ EOF
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     /bin/folders.sh 
+
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt update
 
 # NOTE: This is not required as there is an undocumented flag --chmod
 ENTRYPOINT ["/bin/folders.sh"]

--- a/86_cache_mounts/README.md
+++ b/86_cache_mounts/README.md
@@ -1,0 +1,38 @@
+# README
+
+Demonstrate RUN mount caching package manager downloads.
+
+NOTE: This does not seem to be working on mac. Rebuilds or the show cache do not show existing packages.  
+
+## 🏠 Build Cache
+
+```sh
+# build
+docker build --no-cache --progress=plain -t buildcache -f Dockerfile.buildcache .  
+docker run -it --rm buildcache
+```
+
+## 👀 Build Cache
+
+```sh
+# build
+docker build --no-cache --progress=plain -t showcache -f Dockerfile.showcache .  
+docker run -it --rm showcache
+```
+
+## ⚡️ Show Cache
+
+```sh
+# run
+docker run -it --rm buildcache
+
+# step inside container
+docker run -it --rm --entrypoint /bin/bash buildcache
+```
+
+## 👀 Resources
+
+* How to Speed Up Your Dockerfile with BuildKit Cache Mounts [here](https://vsupalov.com/buildkit-cache-mount-dockerfile/)  
+* GoogleContainerTools/base-images-docker [here](https://github.com/GoogleContainerTools/base-images-docker/blob/master/debian/reproducible/overlay/etc/apt/apt.conf.d/docker-clean)  
+* mount=type=cache more in-depth explanation? [here](https://github.com/moby/buildkit/issues/1673)  
+* RUN --mount=type=cache syntax [here](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/reference.md#run---mounttypecache)  

--- a/86_cache_mounts/README.md
+++ b/86_cache_mounts/README.md
@@ -1,33 +1,67 @@
 # README
 
-Demonstrate RUN mount caching package manager downloads.
+Demonstrate BUILD mount caching package manager downloads.
 
-NOTE: This does not seem to be working on mac. Rebuilds or the show cache do not show existing packages.  
+NOTES:
 
-## 🏠 Build Cache
+* Using `--no-cache` resets the cache.  
+* Using the cache means you don't have to clean up after package installation.  
+
+TODO:
+
+* Why does `touch ./modifyme.txt && echo "modify" >> ./modifyme.txt` this not invalidate context?
+* How are caches shared between images?  
+
+## 👀 Custom Cache
+
+Use a custom folder and cache it.  
 
 ```sh
 # build
-docker build --no-cache --progress=plain -t buildcache -f Dockerfile.buildcache .  
-docker run -it --rm buildcache
-```
+touch ./modifyme.txt && echo "modify" > ./modifyme.txt
+docker build --no-cache --progress=plain -t customcache -f Dockerfile.customcache .  
 
-## 👀 Build Cache
+# repeat this and see the number of files in cache grow
+touch ./modifyme.txt && echo "modify" >> ./modifyme.txt
+docker build --progress=plain -t customcache -f Dockerfile.customcache .  
 
-```sh
-# build
-docker build --no-cache --progress=plain -t showcache -f Dockerfile.showcache .  
-docker run -it --rm showcache
-```
-
-## ⚡️ Show Cache
-
-```sh
-# run
-docker run -it --rm buildcache
+# this will fail as /mycache does not exist
+docker run -it --rm customcache
 
 # step inside container
-docker run -it --rm --entrypoint /bin/bash buildcache
+docker run -it --rm --entrypoint /bin/bash customcache
+```
+
+## Show APT Cache
+
+```sh
+# build
+touch ./modifyme.txt && echo "modify" > ./modifyme.txt
+docker build --no-cache --progress=plain -t showcache -f Dockerfile.showcache .  
+
+# repeat this and see the number of files in cache grow
+touch ./modifyme.txt && echo "modify" >> ./modifyme.txt
+docker build --progress=plain -t showcache -f Dockerfile.showcache .  
+
+# step inside container
+docker run -it --rm --entrypoint /bin/bash showcache
+ls -lR /var/cache/apt
+ls -lR /var/lib/apt
+```
+
+## 🏠 Build APT Cache
+
+Use cache to cache APT packages.  
+
+```sh
+# build
+touch ./modifyme.txt && echo "modify" > ./modifyme.txt
+docker build --no-cache --progress=plain -t buildcache -f Dockerfile.buildcache .  
+
+touch ./modifyme.txt && echo "modify" >> ./modifyme.txt
+docker build --progress=plain -t buildcache -f Dockerfile.buildcache .  
+
+docker run -it --rm buildcache
 ```
 
 ## 👀 Resources


### PR DESCRIPTION
- Look at distroless users.
- Update users and remove v10.  Switch over image paths to new ones documented on repo
- Update paths I'd forgotten about
- Bump certifi from 2021.10.8 to 2022.12.7 in /85_tini/python
- build volumes (#71)
- Bump certifi from 2021.10.8 to 2022.12.7 in /56_pyenv_versions
- Bump got and nodemon in /64_sbom/ts_sbom_test (#69)
- Cache-from example
- Update instructions
- Update readme
- Cache from updates
- Update and improve instructions
- New instructions
- Improve the example
- Better example
- Update cache from example
- Update the cachefrom tests.
- Finish up the cachefrom example
- Update readme.
- Add a table of contents to the readme.
- Cache mounts example.
