### PR TITLE
frontends

### DIFF
--- a/55_multiarch/README.md
+++ b/55_multiarch/README.md
@@ -9,11 +9,25 @@ QEMU example [here](https://github.com/chrisguest75/sysadmin_examples/tree/maste
 * buildx builders
 * build for graviton?
 
-Supported architectures
+Supported architectures  
 
 ```sh
 # list the supported platforms
 docker buildx ls   
+```
+
+## Pulling images architectures
+
+```sh
+# clean out all the images
+docker system prune --all --force
+
+docker pull --platform=linux/arm64 ubuntu:20.04 
+# this will pull but without a tag ubuntu:<none>
+docker pull --platform=linux/amd64 ubuntu:20.04 
+
+# architecture of each image
+docker images -q | xargs -L 1 docker inspect | jq -c '.[] | [.Id, .Architecture, .RepoTags[]]'
 ```
 
 ## 🏠 Build

--- a/91_buildkit_frontends/Dockerfile.addchecksum
+++ b/91_buildkit_frontends/Dockerfile.addchecksum
@@ -5,5 +5,5 @@ WORKDIR /scratch
 ADD --checksum=sha256:24454f830cdb571e2c4ad15481119c43b3cafd48dd869a9b2945d1036d1dc68d https://mirrors.edge.kernel.org/pub/linux/kernel/Historic/linux-0.01.tar.gz /scratch/pass
 
 # FAIL
-ADD --checksum=sha256:24454f830cdb571e2c4ad15481119c43b3cafd48dd869a9b2945d1036d1dc68e https://mirrors.edge.kernel.org/pub/linux/kernel/Historic/linux-0.01.tar.gz /scratch/fail
+# ADD --checksum=sha256:24454f830cdb571e2c4ad15481119c43b3cafd48dd869a9b2945d1036d1dc68e https://mirrors.edge.kernel.org/pub/linux/kernel/Historic/linux-0.01.tar.gz /scratch/fail
 

--- a/91_buildkit_frontends/Dockerfile.addchecksum
+++ b/91_buildkit_frontends/Dockerfile.addchecksum
@@ -1,0 +1,9 @@
+# syntax=docker.io/docker/dockerfile:1.5.0-labs
+FROM ubuntu:20.04 as BASE
+
+WORKDIR /scratch
+ADD --checksum=sha256:24454f830cdb571e2c4ad15481119c43b3cafd48dd869a9b2945d1036d1dc68d https://mirrors.edge.kernel.org/pub/linux/kernel/Historic/linux-0.01.tar.gz /scratch/pass
+
+# FAIL
+ADD --checksum=sha256:24454f830cdb571e2c4ad15481119c43b3cafd48dd869a9b2945d1036d1dc68e https://mirrors.edge.kernel.org/pub/linux/kernel/Historic/linux-0.01.tar.gz /scratch/fail
+

--- a/91_buildkit_frontends/Dockerfile.mixedarch
+++ b/91_buildkit_frontends/Dockerfile.mixedarch
@@ -1,3 +1,35 @@
 # syntax=docker.io/docker/dockerfile:1.4.3
-FROM --platform=arm64 ubuntu:20.04 as BASE
+
+FROM --platform=arm64 ubuntu:20.04 as basearm64
+FROM --platform=amd64 ubuntu:20.04 as baseamd64
+
+### 
+# NOTE: Use the following FROM to switch final imae architecture
+###
+
+#FROM --platform=arm64 ubuntu:20.04 as DIFFERENT
+FROM --platform=amd64 ubuntu:20.04 as DIFFERENT
+
+WORKDIR /scratch
+
+# NOTE: Escape the \$ otherwise they are rendered at buildtime
+COPY --chmod=755 <<EOF /bin/show_architecture.sh
+#!/usr/bin/env bash
+cat /proc/version
+lscpu
+uname -a    
+
+echo "*******************************"
+cat /scratch/arm64_available | grep "arm64"
+echo "*******************************"
+cat /scratch/amd64_available | grep "amd64"
+echo "*******************************"
+
+
+EOF
+
+COPY --from=basearm64 /var/lib/dpkg/available /scratch/arm64_available
+COPY --from=baseamd64 /var/lib/dpkg/available /scratch/amd64_available
+
+ENTRYPOINT ["/bin/bash", "-c", " /bin/show_architecture.sh"]
 

--- a/91_buildkit_frontends/Dockerfile.mixedarch
+++ b/91_buildkit_frontends/Dockerfile.mixedarch
@@ -1,0 +1,3 @@
+# syntax=docker.io/docker/dockerfile:1.4.3
+FROM --platform=arm64 ubuntu:20.04 as BASE
+

--- a/91_buildkit_frontends/README.md
+++ b/91_buildkit_frontends/README.md
@@ -2,10 +2,6 @@
 
 Demonstrate how to use `docker frontends`.  
 
-TODO:
-
-* Link to the buildpacks example.  
-
 ## Reason
 
 BuildKit is a toolkit for converting source code into build artifacts, such as executable files or Docker images, in an efficient, concurrent, and cache-friendly manner. It is primarily used as the backend for building Docker images, but it can also be used independently.  
@@ -25,6 +21,7 @@ Frontends play a crucial role in BuildKit's architecture, as they allow it to be
 ## Examples
 
 * HereDocs [here](../60_heredocs/README.md)  
+* Buildpacks [here](../43_python_buildpacks/README.md)  
 
 ## Build (dockerfile)
 
@@ -52,7 +49,7 @@ docker run -it mixedarch
 
 ## Build (flakes.nix)
 
-Using a frontend that builds `flakes.nix` directly into an image.  This creates 
+Using a frontend that builds `flakes.nix` directly into an image.  This creates an images that has a reproducible hash.  
 
 ```sh
 docker system prune --all --force
@@ -68,6 +65,27 @@ docker images --digests
 nginx-nix latest 94727237fecd 53 years ago 135MB
 ```
 
+Quick demo of non-reproducible builds with docker containers.  
+
+```sh
+docker buildx create --use --driver docker-container --driver-opt network=host --name test1 --platform linux/amd64
+docker buildx create --use --driver docker-container --driver-opt network=host --name test2 --platform linux/amd64
+
+export BASEIMAGE=scratch
+docker buildx build --builder test1 --platform linux/amd64 --load --build-arg=baseimage=$BASEIMAGE --progress=plain -f Dockerfile.ffmpeg --target PRODUCTION -t ffmpeg-test1 .
+docker buildx build --builder test2 --platform linux/amd64 --load --build-arg=baseimage=$BASEIMAGE --progress=plain -f Dockerfile.ffmpeg --target PRODUCTION -t ffmpeg-test2 .
+
+
+docker images --digests
+```
+
+The same build produces different SHA.  
+
+```log
+ffmpeg-test2 latest <none> 1646a702dff0 About a minute ago   153MB
+ffmpeg-test1 latest <none> 994057e9efdf 5 minutes ago        153MB
+```
+
 ## Resources
 
 * Dockerfile frontend syntaxes [here](https://github.com/moby/buildkit/blob/dockerfile/1.4.0/frontend/dockerfile/docs/syntax.md#linked-copies-copy---link-add---link)  
@@ -78,5 +96,3 @@ nginx-nix latest 94727237fecd 53 years ago 135MB
 * dockerhub docker/dockerfile-upstream [here](https://hub.docker.com/r/docker/dockerfile-upstream)
 * Exploring LLB [here](https://github.com/moby/buildkit#exploring-llb)
 * envd (ɪnˈvdɪ) is a command-line tool that helps you create the container-based development environment for AI/ML. [here](https://github.com/tensorchord/envd/)  
-
-https://github.com/reproducible-containers/buildkit-nix

--- a/91_buildkit_frontends/README.md
+++ b/91_buildkit_frontends/README.md
@@ -1,0 +1,73 @@
+# FRONTENDS
+
+Demonstrate how to use `docker frontends`.  
+
+## Reason
+
+BuildKit is a toolkit for converting source code into build artifacts, such as executable files or Docker images, in an efficient, concurrent, and cache-friendly manner. It is primarily used as the backend for building Docker images, but it can also be used independently.  
+
+BuildKit frontends are the components that define how BuildKit should interpret and process the build instructions. These frontends parse build files (such as Dockerfiles) and translate them into a format that BuildKit's core can understand, known as the intermediate representation (IR). The IR is a lower-level format that represents the build graph, which BuildKit's core uses to execute the build process.  
+
+There are different frontends available for BuildKit, each catering to different build systems or languages. Some examples of BuildKit frontends are:  
+
+* Dockerfile frontend (dockerfile.v0): This is the default frontend for BuildKit and is designed to process Dockerfiles. It understands Dockerfile syntax and translates it into a format that BuildKit can use.  
+
+* LLB (Low-Level Builder) frontend (gateway.v0): This frontend is for those who want more control over the build process than what Dockerfiles can provide. It allows users to define the build graph using the LLB format directly, which is the same format that BuildKit uses internally. This provides more flexibility and finer control over the build process.  
+
+* Custom frontends: Users can create their own custom frontends to handle specific build systems, languages, or other unique requirements. These frontends can be written in any language, as long as they can communicate with BuildKit's core using gRPC.  
+
+Frontends play a crucial role in BuildKit's architecture, as they allow it to be flexible and support a wide range of build systems, making it a versatile tool for developers.  
+
+## Examples
+
+* HereDocs [here](../60_heredocs/README.md)  
+
+## Build (dockerfile)
+
+### Add checksums
+
+```sh
+docker buildx build --progress=plain -f Dockerfile.addchecksum -t addchecksum .
+
+dive addchecksum
+```
+
+### FROM arch
+
+```sh
+```
+
+## Build (flakes.nix)
+
+NOTE: This is not working yet.  
+
+```sh
+# looks like the file has to be called flake.nix
+docker buildx build -t nginx-nix -f ./flake.nix .
+```
+
+```log
+nginx-nix                  latest            45caff172034   53 years ago     135MB
+```
+
+```sh
+docker run -d -p 8080:80 --read-only --name nginx-nix nginx-nix
+```
+
+## Resources
+
+* Dockerfile frontend syntaxes [here](https://github.com/moby/buildkit/blob/dockerfile/1.4.0/frontend/dockerfile/docs/syntax.md#linked-copies-copy---link-add---link)  
+* Dockerhub BuildKit Dockerfile frontend [here](https://hub.docker.com/r/docker/dockerfile)
+* Custom Dockerfile syntax [here](https://docs.docker.com/build/buildkit/dockerfile-frontend/)
+
+https://hub.docker.com/r/docker/dockerfile-upstream
+
+https://github.com/moby/buildkit#exploring-llb
+https://github.com/reproducible-containers/buildkit-nix
+
+https://github.com/tensorchord/envd/
+
+https://github.com/reproducible-containers/buildkit-nix/tree/master/examples/golang-httpserver-flake
+
+https://github.com/reproducible-containers/buildkit-nix/blob/master/examples/nginx-flake/flake.nix
+

--- a/91_buildkit_frontends/README.md
+++ b/91_buildkit_frontends/README.md
@@ -30,15 +30,24 @@ Frontends play a crucial role in BuildKit's architecture, as they allow it to be
 
 ### Add checksums
 
-```sh
-docker buildx build --progress=plain -f Dockerfile.addchecksum -t addchecksum .
+Based on buildkit frontend [1.5.0 release](https://github.com/moby/buildkit/releases/tag/dockerfile%2F1.5.0-labs).  `ADD` now supports a checksum.  
 
+```sh
+# download a file with a checksum
+docker buildx build --progress=plain -f Dockerfile.addchecksum -t addchecksum .
+# check it exists
 dive addchecksum
 ```
 
 ### FROM arch
 
+You can override the architecture in the docker file.  
+Using this technique you can use an AMD64 build to build some tooling or config for an ARM64 final image.  
+
 ```sh
+docker buildx build --progress=plain -f Dockerfile.mixedarch -t mixedarch .
+# examine output and see ARM64 and AMD64 strings coming from different architectures
+docker run -it mixedarch
 ```
 
 ## Build (flakes.nix)

--- a/91_buildkit_frontends/README.md
+++ b/91_buildkit_frontends/README.md
@@ -20,8 +20,12 @@ Frontends play a crucial role in BuildKit's architecture, as they allow it to be
 
 ## Examples
 
+Examples here are based on other examples.  
+
 * HereDocs [here](../60_heredocs/README.md)  
 * Buildpacks [here](../43_python_buildpacks/README.md)  
+* Multiarchitecture [here](../55_multiarch/README.md)  
+* Builders [here](../90_builders/README.md)  
 
 ## Build (dockerfile)
 

--- a/91_buildkit_frontends/README.md
+++ b/91_buildkit_frontends/README.md
@@ -52,19 +52,20 @@ docker run -it mixedarch
 
 ## Build (flakes.nix)
 
-NOTE: This is not working yet.  
+Using a frontend that builds `flakes.nix` directly into an image.  This creates 
 
 ```sh
+docker system prune --all --force
 # looks like the file has to be called flake.nix
 docker buildx build -t nginx-nix -f ./flake.nix .
+docker run -it -p 8080:80 --rm --name nginx-nix nginx-nix
+curl http://localhost:8080 
+
+docker images --digests
 ```
 
 ```log
-nginx-nix                  latest            45caff172034   53 years ago     135MB
-```
-
-```sh
-docker run -d -p 8080:80 --read-only --name nginx-nix nginx-nix
+nginx-nix latest 94727237fecd 53 years ago 135MB
 ```
 
 ## Resources
@@ -73,15 +74,9 @@ docker run -d -p 8080:80 --read-only --name nginx-nix nginx-nix
 * Dockerhub BuildKit Dockerfile frontend [here](https://hub.docker.com/r/docker/dockerfile)
 * Custom Dockerfile syntax [here](https://docs.docker.com/build/buildkit/dockerfile-frontend/)
 * Demystifying the Buildpacks frontend for BuildKit [here](https://shemleong.medium.com/demystifying-the-buildpacks-buildkit-frontend-6e9378001c6c)  
+* nginx reproducible-containers/buildkit-nix [here](https://github.com/reproducible-containers/buildkit-nix/blob/master/examples/nginx-flake/flake.nix)  
+* dockerhub docker/dockerfile-upstream [here](https://hub.docker.com/r/docker/dockerfile-upstream)
+* Exploring LLB [here](https://github.com/moby/buildkit#exploring-llb)
+* envd (ɪnˈvdɪ) is a command-line tool that helps you create the container-based development environment for AI/ML. [here](https://github.com/tensorchord/envd/)  
 
-https://hub.docker.com/r/docker/dockerfile-upstream
-
-https://github.com/moby/buildkit#exploring-llb
 https://github.com/reproducible-containers/buildkit-nix
-
-https://github.com/tensorchord/envd/
-
-https://github.com/reproducible-containers/buildkit-nix/tree/master/examples/golang-httpserver-flake
-
-https://github.com/reproducible-containers/buildkit-nix/blob/master/examples/nginx-flake/flake.nix
-

--- a/91_buildkit_frontends/README.md
+++ b/91_buildkit_frontends/README.md
@@ -2,6 +2,10 @@
 
 Demonstrate how to use `docker frontends`.  
 
+TODO:
+
+* Link to the buildpacks example.  
+
 ## Reason
 
 BuildKit is a toolkit for converting source code into build artifacts, such as executable files or Docker images, in an efficient, concurrent, and cache-friendly manner. It is primarily used as the backend for building Docker images, but it can also be used independently.  
@@ -59,6 +63,7 @@ docker run -d -p 8080:80 --read-only --name nginx-nix nginx-nix
 * Dockerfile frontend syntaxes [here](https://github.com/moby/buildkit/blob/dockerfile/1.4.0/frontend/dockerfile/docs/syntax.md#linked-copies-copy---link-add---link)  
 * Dockerhub BuildKit Dockerfile frontend [here](https://hub.docker.com/r/docker/dockerfile)
 * Custom Dockerfile syntax [here](https://docs.docker.com/build/buildkit/dockerfile-frontend/)
+* Demystifying the Buildpacks frontend for BuildKit [here](https://shemleong.medium.com/demystifying-the-buildpacks-buildkit-frontend-6e9378001c6c)  
 
 https://hub.docker.com/r/docker/dockerfile-upstream
 

--- a/91_buildkit_frontends/flake.nix
+++ b/91_buildkit_frontends/flake.nix
@@ -1,0 +1,52 @@
+# syntax = ghcr.io/reproducible-containers/buildkit-nix:v0.1.0@sha256:c727e0efc2a3aa23bbd31404701b5eee420ada1f08c7d4e21d666f24804355b6
+
+{
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        entrypoint = pkgs.writeScript "docker-entrypoint.sh" ''
+          #!${pkgs.stdenv.shell}
+          set -eux -o pipefail
+          # Create "nogroup" group
+          if ! grep -q ^nogroup /etc/group; then
+            # dereference symlink (/etc/group -> /nix/....) to support `docker run --read-only`
+            cp -aL /etc/group /etc/group.real
+            echo nogroup:x:65534: >>/etc/group.real
+            rm -f /etc/group
+            mv /etc/group.real /etc/group
+          fi
+          # Initialize /var
+          mkdir -p /var/log/nginx /var/cache/nginx/client_body
+          exec nginx -g "daemon off; error_log /dev/stderr debug;"
+        '';
+      in with pkgs; rec {
+        defaultPackage = dockerTools.buildImage {
+          name = "nginx";
+          tag = "nix";
+          contents = [
+            # fakeNss creates /etc/passwd and /etc/group (https://github.com/NixOS/nixpkgs/blob/e548124f/pkgs/build-support/docker/default.nix#L741-L763)
+            dockerTools.fakeNss
+            bash
+            coreutils
+            gnugrep
+            nginx
+            (writeTextDir "${pkgs.nginx}/html/index.html" ''
+              <html><body>hello nix</body></html>
+            '')
+          ];
+          # runAsRoot cannot be used because it depends on KVM.
+          # extraCommands can be used but often fails unless running everything as the root.
+          # https://discourse.nixos.org/t/dockertools-buildimage-and-user-writable-tmp/5397
+          config = {
+            Cmd = [ entrypoint ];
+            ExposedPorts = { "80/tcp" = { }; };
+            Volumes = {
+              "/etc" = { };
+              "/var" = { };
+            };
+          };
+        };
+      });
+}

--- a/91_buildkit_frontends/flake.nix
+++ b/91_buildkit_frontends/flake.nix
@@ -19,6 +19,7 @@
           fi
           # Initialize /var
           mkdir -p /var/log/nginx /var/cache/nginx/client_body
+          mkdir -p /tmp
           exec nginx -g "daemon off; error_log /dev/stderr debug;"
         '';
       in with pkgs; rec {


### PR DESCRIPTION
- Look at distroless users.
- Update users and remove v10.  Switch over image paths to new ones documented on repo
- Update paths I'd forgotten about
- Bump certifi from 2021.10.8 to 2022.12.7 in /85_tini/python
- build volumes (#71)
- Bump certifi from 2021.10.8 to 2022.12.7 in /56_pyenv_versions
- Bump got and nodemon in /64_sbom/ts_sbom_test (#69)
- Cache-from example
- Update instructions
- Update readme
- Cache from updates
- Update and improve instructions
- New instructions
- Improve the example
- Better example
- Update cache from example
- Update the cachefrom tests.
- Finish up the cachefrom example
- Update readme.
- Add a table of contents to the readme.
- A simple volume share example
- Add wasi example
- Add lazy pulling
- Add examples that push to ecr.
- Add a few bits to readme.
- Add info on managing diskspace.
- Update README.md
- Playing with builders (#78)
- Start looking at different frontends.
